### PR TITLE
Hash dicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ This will be used by [openregister-java]() to provide a verifiable log of data. 
 The set of types supported this objecthash implementation are:
 - Integer
 - Unicode string
+- List
 - Set
+- Hash
 - Timestamp
 
 Timestamp is an extension.
 It represents a datetime in UTC with seconds precision, and is encoded by taking the ISO8601 string representation and prefixing with the tag "t".
 
-Objecthash-java does not implement Boolean, Float, or Array types.
+objecthash-java does not implement Boolean or Float types.
 
 ### Redacting primitive values
 

--- a/src/main/java/DictValue.java
+++ b/src/main/java/DictValue.java
@@ -1,0 +1,56 @@
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DictValue implements ObjectHashable {
+    private final Map<String, ObjectHashable> data;
+
+    public DictValue() {
+        this.data = new HashMap<String, ObjectHashable>();
+    }
+    
+    public DictValue(Map<String, ObjectHashable> data) {
+        this.data = data;
+    }
+    
+    public byte[] getBytes() throws NoSuchAlgorithmException {
+        MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+        
+        List<byte[]> hashValues = new ArrayList<>();
+        for (Map.Entry<String, ObjectHashable> entry : this.data.entrySet()) {
+            ObjectHashable value = entry.getValue();
+            ObjectHashable key = new StringValue(entry.getKey());
+            if (value != null) {
+                // TODO: what about blank strings?
+                hashValues.add(concatEntryHashes(key.getBytes(), value.getBytes()));
+            }
+        }
+        hashValues.sort((a, b) -> compareBytes(a, b));
+        sha256.update(ObjectHash.DICT_VALUE_TAG.getBytes(StandardCharsets.UTF_8));
+        hashValues.stream().forEach(bytes -> sha256.update(bytes));
+        
+        return sha256.digest();
+    }
+
+    private int compareBytes(byte[] left, byte[] right) {
+        for (int i = 0, j = 0; i < left.length && j < right.length; i++, j++) {
+            int a = (left[i] & 0xff);
+            int b = (right[j] & 0xff);
+            if (a != b) {
+                return a - b;
+            }
+        }
+        return left.length - right.length;
+    }
+    
+    private byte[] concatEntryHashes(byte[] attrHash, byte[] valueHash) {
+        byte[] concattedHash = new byte[attrHash.length + valueHash.length];
+        System.arraycopy(attrHash, 0, concattedHash, 0, attrHash.length);
+        System.arraycopy(valueHash, 0, concattedHash, attrHash.length, valueHash.length);
+        return concattedHash;
+    }
+}

--- a/src/main/java/ObjectHash.java
+++ b/src/main/java/ObjectHash.java
@@ -1,22 +1,15 @@
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.text.Normalizer;
+import java.util.Map;
 
 public final class ObjectHash {
-    
-    
-    private static final String STRING_TAG = "u";
+    public static final String STRING_VALUE_TAG = "u";
+    public static final String DICT_VALUE_TAG = "d";
 
     public String hexDigest (String value) throws NoSuchAlgorithmException {
-        MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
-        sha256.update(STRING_TAG.getBytes(StandardCharsets.UTF_8));
-        String normalisedValue = Normalizer.normalize(value, Normalizer.Form.NFC);
-        sha256.update(normalisedValue.getBytes(StandardCharsets.UTF_8));
-        StringBuilder sb = new StringBuilder();
-        for (byte b : sha256.digest()) {
-            sb.append(String.format("%02x", b));
-        }
-        return sb.toString();
+        return new StringValue(value).hexDigest();
     }
+    
+    public String hexDigest (Map<String, ObjectHashable> value) throws NoSuchAlgorithmException {
+        return new DictValue(value).hexDigest();
+    } 
 }

--- a/src/main/java/ObjectHashable.java
+++ b/src/main/java/ObjectHashable.java
@@ -1,0 +1,13 @@
+import java.security.NoSuchAlgorithmException;
+
+public interface ObjectHashable {
+    default String hexDigest() throws NoSuchAlgorithmException {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : getBytes()) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+    
+    byte[] getBytes() throws NoSuchAlgorithmException;
+}

--- a/src/main/java/StringValue.java
+++ b/src/main/java/StringValue.java
@@ -1,0 +1,20 @@
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.Normalizer;
+
+public class StringValue implements ObjectHashable {
+    private final String value;
+    
+    public StringValue(String value) {
+        this.value = value;
+    }
+    
+    public byte[] getBytes() throws NoSuchAlgorithmException {
+        MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+        sha256.update(ObjectHash.STRING_VALUE_TAG.getBytes(StandardCharsets.UTF_8));
+        String normalisedValue = Normalizer.normalize(value, Normalizer.Form.NFC);
+        sha256.update(normalisedValue.getBytes(StandardCharsets.UTF_8));
+        return sha256.digest();
+    }
+}

--- a/src/test/java/ObjectHashTest.java
+++ b/src/test/java/ObjectHashTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.*;
 
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ObjectHashTest {
     @Test
@@ -21,5 +23,13 @@ public class ObjectHashTest {
         assertEquals(classUnderTest.hexDigest("\u03d2\u0301"), "f72826713a01881404f34975447bd6edcb8de40b191dc57097ebf4f5417a554d" );
     }
 
-
+    @Test
+    public void hashesDict() throws NoSuchAlgorithmException {
+        ObjectHash objectHash = new ObjectHash();
+        Map<String, ObjectHashable> data = new HashMap<>();
+        data.put("foo", new StringValue("bar"));
+        data.put("null", null);
+        String digest = objectHash.hexDigest(data);
+        assertEquals(digest, "7ef5237c3027d6c58100afadf37796b3d351025cf28038280147d42fdc53b960");
+    }
 }


### PR DESCRIPTION
The hashing of dicts is defined in this RFC:
https://github.com/openregister/registers-rfcs/blob/master/content/item-hash/index.md

I've interpreted this as:

1. Hash the key and the value for every value
2. Concat the keyHash and valueHash of every pair
3. Sort the resulting list of concatted hashes
4. Prefix the list with "d"
5. Hash the result

In order to implement this I needed a way to define the type of dict values so I've refactored the library to use an interface `ObjectHashable` and classes for each objecthash type.

For the moment I'm ignoring null values, but I'm not doing anything special with empty strings. I'm thinking that our treatment of empty strings in registers is part of [item normalisation](https://github.com/openregister/registers-rfcs/blob/master/content/blob-normalisation/index.md) and it should be left out of the objecthash code.