### PR TITLE
Add redaction support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api 'org.apache.commons:commons-math3:3.6.1'
 
+    // https://mvnrepository.com/artifact/commons-codec/commons-codec
+    compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
+
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:23.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api 'org.apache.commons:commons-math3:3.6.1'
 
-    // https://mvnrepository.com/artifact/commons-codec/commons-codec
     compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 23 10:30:05 GMT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/src/main/java/uk/gov/objecthash/ObjectHashable.java
+++ b/src/main/java/uk/gov/objecthash/ObjectHashable.java
@@ -1,5 +1,6 @@
 package uk.gov.objecthash;
 
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -36,6 +37,11 @@ public interface ObjectHashable {
             sb.append(String.format("%02x", b));
         }
         return sb.toString();
+    }
+
+
+    default StringValue redacted() {
+        return new StringValue("**REDACTED**" + hexDigest());
     }
     
     byte[] digest();

--- a/src/main/java/uk/gov/objecthash/ObjectHashable.java
+++ b/src/main/java/uk/gov/objecthash/ObjectHashable.java
@@ -38,11 +38,6 @@ public interface ObjectHashable {
         }
         return sb.toString();
     }
-
-
-    default StringValue redacted() {
-        return new StringValue("**REDACTED**" + hexDigest());
-    }
     
     byte[] digest();
 }

--- a/src/main/java/uk/gov/objecthash/StringValue.java
+++ b/src/main/java/uk/gov/objecthash/StringValue.java
@@ -2,10 +2,6 @@ package uk.gov.objecthash;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
-import uk.gov.objecthash.exceptions.InvalidRedactedValue;
-
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 
 public class StringValue implements ObjectHashable {
     private final String value;
@@ -20,7 +16,13 @@ public class StringValue implements ObjectHashable {
             try {
                 return Hex.decodeHex(hexDigest);
             } catch (DecoderException e) {
-                throw new InvalidRedactedValue("Invalid hex digest: " + hexDigest, e);
+                /* 
+                 * If the redacted value is not valid hex, then treat it as
+                 * a non-redacted string. This ensures that every possible
+                 * data structure has a hash. We do not enforce that the hash
+                 * length matches any particular hashing algorithm, only that
+                 * it is hex encoded.
+                 */
             }
         }
         

--- a/src/main/java/uk/gov/objecthash/StringValue.java
+++ b/src/main/java/uk/gov/objecthash/StringValue.java
@@ -1,5 +1,12 @@
 package uk.gov.objecthash;
 
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import uk.gov.objecthash.exceptions.InvalidRedactedValue;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
 public class StringValue implements ObjectHashable {
     private final String value;
     
@@ -8,6 +15,15 @@ public class StringValue implements ObjectHashable {
     }
     
     public byte[] digest() {
+        if(value.startsWith("**REDACTED**")) {
+            final String hexDigest = value.substring(12);
+            try {
+                return Hex.decodeHex(hexDigest);
+            } catch (DecoderException e) {
+                throw new InvalidRedactedValue("Invalid hex digest: " + hexDigest, e);
+            }
+        }
+        
         return ObjectHashable.digest(ObjectHashable.STRING_TAG, value);
     }
 }

--- a/src/main/java/uk/gov/objecthash/exceptions/InvalidRedactedValue.java
+++ b/src/main/java/uk/gov/objecthash/exceptions/InvalidRedactedValue.java
@@ -1,0 +1,7 @@
+package uk.gov.objecthash.exceptions;
+
+public class InvalidRedactedValue extends RuntimeException {
+    public InvalidRedactedValue(String errorMessage, Throwable err) {
+        super(errorMessage, err);
+    }
+}

--- a/src/main/java/uk/gov/objecthash/exceptions/InvalidRedactedValue.java
+++ b/src/main/java/uk/gov/objecthash/exceptions/InvalidRedactedValue.java
@@ -1,7 +1,0 @@
-package uk.gov.objecthash.exceptions;
-
-public class InvalidRedactedValue extends RuntimeException {
-    public InvalidRedactedValue(String errorMessage, Throwable err) {
-        super(errorMessage, err);
-    }
-}

--- a/src/test/java/uk/gov/objecthash/ObjectHashTest.java
+++ b/src/test/java/uk/gov/objecthash/ObjectHashTest.java
@@ -1,6 +1,5 @@
 package uk.gov.objecthash;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -13,13 +12,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 
 public class ObjectHashTest {
-    
+
     @Test
-    public void hashesStrings()  {
+    public void hashesStrings() {
         assertEquals(ObjectHash.toHexDigest("Hello, Ruby!"), "c92765c1350e6df6800dbadedb3420f398d5f3c7e38a3da48aadb3332280f85f");
     }
 
@@ -45,19 +45,19 @@ public class ObjectHashTest {
     
     @Test
     public void hashesIntegers() {
-        assertEquals(ObjectHash.toHexDigest(-1), "f105b11df43d5d321f5c773ef904af979024887b4d2b0fab699387f59e2ff01e" );
-        assertEquals(ObjectHash.toHexDigest(0), "a4e167a76a05add8a8654c169b07b0447a916035aef602df103e8ae0fe2ff390" );
-        assertEquals(ObjectHash.toHexDigest(10), "73f6128db300f3751f2e509545be996d162d20f9e030864632f85e34fd0324ce" );
-        assertEquals(ObjectHash.toHexDigest(1000), "a3346d18105ef801c3598fec426dcc5d4be9d0374da5343f6c8dcbdf24cb8e0b" );
-    }    
-    
+        assertEquals(ObjectHash.toHexDigest(-1), "f105b11df43d5d321f5c773ef904af979024887b4d2b0fab699387f59e2ff01e");
+        assertEquals(ObjectHash.toHexDigest(0), "a4e167a76a05add8a8654c169b07b0447a916035aef602df103e8ae0fe2ff390");
+        assertEquals(ObjectHash.toHexDigest(10), "73f6128db300f3751f2e509545be996d162d20f9e030864632f85e34fd0324ce");
+        assertEquals(ObjectHash.toHexDigest(1000), "a3346d18105ef801c3598fec426dcc5d4be9d0374da5343f6c8dcbdf24cb8e0b");
+    }
+
     @Test
     public void hashesTimestamps() {
         var date = LocalDate.parse("2000-01-01");
         Instant instant = date.atStartOfDay(ZoneId.of("UTC")).toInstant();
-        assertEquals(ObjectHash.toHexDigest(instant), "cb34961d3d1a44386a73c37eb64c72a2b61ff40fc108abca92ef07c4954a1645" );
+        assertEquals(ObjectHash.toHexDigest(instant), "cb34961d3d1a44386a73c37eb64c72a2b61ff40fc108abca92ef07c4954a1645");
     }
-    
+
     @Test
     public void hashesDict() {
         Map<String, ObjectHashable> data = new HashMap<>();
@@ -136,4 +136,17 @@ public class ObjectHashTest {
 
         assertEquals("45d9392ad17cead3fa46501eba3e5ac237cb46a39f1e175905f00ef6a6667257", digest);
     }
+
+    @Test
+    public void returnsSuppliedHashIfRedacted() {
+        StringValue original = new StringValue("hello");
+        
+        assertEquals(original.hexDigest(), original.redacted().hexDigest());
+    }
+
+    @Test
+    public void hashesKnownRedactedHash() {
+        assertEquals(ObjectHash.toHexDigest("**REDACTED**2a42a9c91b74c0032f6b8000a2c9c5bcca5bb298f004e8eff533811004dea511"), "2a42a9c91b74c0032f6b8000a2c9c5bcca5bb298f004e8eff533811004dea511" );
+    }
+
 }

--- a/src/test/java/uk/gov/objecthash/ObjectHashTest.java
+++ b/src/test/java/uk/gov/objecthash/ObjectHashTest.java
@@ -140,8 +140,9 @@ public class ObjectHashTest {
     @Test
     public void returnsSuppliedHashIfRedacted() {
         StringValue original = new StringValue("hello");
+        StringValue redacted = new StringValue("**REDACTED**" + original.hexDigest());
         
-        assertEquals(original.hexDigest(), original.redacted().hexDigest());
+        assertEquals(original.hexDigest(), redacted.hexDigest());
     }
 
     @Test

--- a/src/test/java/uk/gov/objecthash/ObjectHashTest.java
+++ b/src/test/java/uk/gov/objecthash/ObjectHashTest.java
@@ -148,5 +148,10 @@ public class ObjectHashTest {
     public void hashesKnownRedactedHash() {
         assertEquals(ObjectHash.toHexDigest("**REDACTED**2a42a9c91b74c0032f6b8000a2c9c5bcca5bb298f004e8eff533811004dea511"), "2a42a9c91b74c0032f6b8000a2c9c5bcca5bb298f004e8eff533811004dea511" );
     }
+    
+    @Test
+    public void hashesInvalidRedactedValues() {
+        assertEquals(ObjectHash.toHexDigest("**REDACTED**banana"), "525b975c2979f427dcb79db8992035a9c2157a3c54492050753b9af552756c7a");
+    }
 
 }


### PR DESCRIPTION
If a string starts with the string `**REDACTED**` followed by a hex digest, the hash is just the hash represented by that hex.