### PR TITLE
deploy to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,9 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+deploy:
+  provider: script
+  script: './gradlew clean build -x test && ./gradlew bintrayUpload'
+  on:
+    branch: master
+

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,46 @@
 plugins {
     // Apply the java-library plugin to add support for Java Library
     id 'java-library'
+    id "com.jfrog.bintray" version "1.8.4"
+    id 'maven'
+    id 'maven-publish'
+}
+
+def majorMinorVersion = '0.1'
+def buildNumber = System.getenv('TRAVIS_BUILD_NUMBER') ? System.getenv('TRAVIS_BUILD_NUMBER') : '0000'
+def versionNumber = majorMinorVersion + '.' + buildNumber
+
+group 'objecthash-java'
+version versionNumber
+
+publishing {
+    publications {
+        JarPublication(MavenPublication) {
+            from components.java
+            groupId 'objecthash-java'
+            artifactId 'objecthash-java'
+            version versionNumber
+        }
+    }
+}
+
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_KEY')
+    publications = ['JarPublication']
+    publish = true
+    pkg {
+        repo = 'openregister'
+        name = 'objecthash-java'
+        userOrg = 'openregister'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/openregister/objecthash-java.git'
+        version {
+            name = versionNumber
+            released = new Date()
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Publish to bintray using gradle bintray plugin and travis deployment task (very similar to approach of https://github.com/openregister/verifiable-log/pull/15)

Note I called it `objecthash-java` to match the repo. Though language is obviously java in this context, so we could call it `objecthash` but I thought there is some benefit in being consistent with the repo name. Let me know if you feel strongly about this.
 