### PR TITLE
do not rebuild in deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
     - $HOME/.gradle/wrapper/
 deploy:
   provider: script
-  script: './gradlew clean build -x test && ./gradlew bintrayUpload'
+  script: './gradlew bintrayUpload'
   on:
     branch: master
 


### PR DESCRIPTION
### Context
Deploy to bintray was failing in the deploy step

### Changes proposed in this pull request
Try removing the additional build, as it appears Travis has done this already by default

### Guidance to review
Should deploy to bintray when merged to master.
